### PR TITLE
Prevent Users from Escalating their Role to Owner

### DIFF
--- a/src/Policies/MembershipPolicy.php
+++ b/src/Policies/MembershipPolicy.php
@@ -50,6 +50,11 @@ class MembershipPolicy{
 			return false;
 		}
 
+		if( $newRole->hasFlag( RoleFlag::Owner ) ){
+			// You may not premote yourself to owner.
+			return false;
+		}
+
 		return $membership->getTeam()->userCan( $user, 'membership.update' );
 	}
 


### PR DESCRIPTION
This PR prevents users from being able to assign their role to owner.

The owner role can still be assigned programmatically but the MembershipPolicy now includes a check in the updateRole guard. This prevents users from setting the role to Owner via the Sleepy API routes.

This applies to all Roles with the RoleFlag::Owner flag set.

> ⚠️ If authors introduce other roles with unlimited permissions or other high-stakes roles then this protection does not apply to them.