### PR TITLE
Find abandoned teams

### DIFF
--- a/src/Console/Commands/AbandonedCommand.php
+++ b/src/Console/Commands/AbandonedCommand.php
@@ -1,0 +1,177 @@
+<?php
+ 
+namespace WRD\Teamsy\Console\Commands;
+
+use Illuminate\Console\Command;
+use Illuminate\Support\Arr;
+use Illuminate\Support\Str;
+use Symfony\Component\Console\Helper\Table;
+use WRD\Teamsy\Models\TeamInspector;
+
+class AbandonedCommand extends Command
+{
+    /**
+     * The name and signature of the console command.
+     *
+     * @var string
+     */
+    protected $signature = 'teamsy:abandoned {model?} {--all : Show the membership count of all teams, not just those with no members}';
+ 
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'List the teams with no members.';
+ 
+    /**
+     * Execute the console command.
+     */
+    public function handle( TeamInspector $inspector ): void
+    {
+        $models = $this->argument( 'model' ) ?
+            [ $this->guessModel() ]
+            : $inspector->getAllTeamModels();
+
+        $this->line( '<fg=gray>Finding abandoned teams...</>' );
+        $this->line( PHP_EOL );
+
+        $populated = 0;
+        $total = 0;
+
+        foreach( $models as $model ){
+            if( ! $inspector->isValidTeam( $model ) ){
+                $this->error( "$model is not a valid team." );
+                return;
+            }
+
+            $teams = $inspector->getTeamCounts( $model );
+            $populated += collect( $teams )->map( fn( $team ) => $team->members_count )->sum();
+            $total += count( $teams );
+            
+            $this->outputTable( $model, $teams );
+        }
+
+        $abandoned = $total - $populated;
+        $name = Str::of( 'team' )->plural( $abandoned );
+        $this->line( "<fg=gray>Found </><fg=bright-white>$abandoned</><fg=gray> abandoned $name out of </><fg=bright-white>$total</><fg=gray> total.</>" );
+    }
+
+    private function guessModel(): string {
+        $model = $this->argument( 'model' );
+
+        if( Str::startsWith( $model, '\\') ){
+            dd( $model );
+            return $model; // User has likely qualified this model with a namespace.
+        }
+
+        return "\\App\\Models\\$model";
+    }
+
+    private function outputTable( string $model, array $teams ){
+        $table = (new Table( $this->output ))
+            ->setStyle( 'box' )
+            ->setHeaders([
+                'ID',
+                'Members',
+                'Invitations',
+                'Status',
+                'Action'
+            ]);
+
+        $title = Str::of( $model )->classBasename()->headline()->plural();
+        $table->setHeaderTitle( $title );
+
+        $onlyAbandoned = ! $this->option( 'all' );
+
+        $abandoned = 0;
+        $total = 0;
+
+        foreach( $teams as $team ){
+            $isAbandoned = $team->members_count === 0;
+
+            $total++;
+            $abandoned += $isAbandoned ? 1 : 0;
+
+            if( $onlyAbandoned && ! $isAbandoned ){
+                continue;
+            }
+
+            $keyLine = "<fg=gray>#</>" . $team->getKey();
+
+            $membersLine = Str::of( "member" )
+                ->plural( $team->members_count )
+                ->wrap( "<fg=gray>", "</>" )
+                ->prepend( $this->highlightCount( $team->members_count ), " " );
+
+            $invitesLine = Str::of( "invite" )
+                ->plural( $team->invitations_count )
+                ->wrap( "<fg=gray>", "</>" )
+                ->prepend( $this->highlightCount( $team->invitations_count ), " " );
+
+            $status = $isAbandoned ? "Abandoned" : "Populated";
+            $statusLine = $this->highlightStatus( $status );
+
+            $action = $isAbandoned ? "Skipped" : "Ignored";
+            $actionLine = $this->highlightAction( $action );
+
+            $table->addRow([
+                $keyLine,
+                $membersLine,
+                $invitesLine,
+                $statusLine,
+                $actionLine
+            ]);
+        }
+
+        
+        $table->render();
+
+        $name = Str::of( $model )->classBasename()->headline()->lower()->plural( $abandoned );
+        $this->line( "<fg=gray>Found </><fg=bright-white>$abandoned</><fg=gray> abandoned $name out of </><fg=bright-white>$total</><fg=gray> total.</>" );
+        $this->line( PHP_EOL );
+    }
+
+    private function highlightCount( int $count ): string{
+        $colors = [
+            0 => "red",
+            1 => "yellow",
+            2 => "yellow"
+        ];
+
+        $color = $colors[$count] ?? "white";
+
+        return sprintf("<fg=%s>%s</>", $color, $count);
+    }
+
+    private function highlightStatus( string $status ): string{
+        $colors = [
+            'Abandoned' => "red",
+            'Populated' => "gray",
+        ];
+
+        if( ! array_key_exists( $status, $colors ) ){
+            $status .= ' (?)';
+        }
+
+        $color = $colors[$status] ?? "magenta";
+
+        return sprintf("<fg=%s>%s</>", $color, $status);
+    }
+
+    private function highlightAction( string $action ): string{
+        $colors = [
+            'Ignored' => "gray",
+            'Skipped' => "bright-white",
+            'Deleted' => "red"
+        ];
+
+        if( ! array_key_exists( $action, $colors ) ){
+            $action .= ' (?)';
+        }
+
+        $color = $colors[$action] ?? "magenta";
+
+        return sprintf("<fg=%s>%s</>", $color, $action);
+    }
+}

--- a/src/Models/TeamInspector.php
+++ b/src/Models/TeamInspector.php
@@ -1,0 +1,53 @@
+<?php
+
+namespace WRD\Teamsy\Models;
+
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Support\Facades\File;
+use Illuminate\Support\Str;
+use ReflectionClass;
+use WRD\Teamsy\Traits\HasTeam;
+
+class TeamInspector{
+	public function getAllTeamModels(): array{
+		$files = File::allFiles( app_path() );
+		$models = collect( $files )
+			->map(function( $file ){
+				$path = $file->getRelativePathname();
+				$unresolved = Str::of( $path )->before(".")->replace( "/", "\\" );
+				$class = '\\' . app()->getNamespace() . $unresolved;
+
+				return $class;
+			})
+			->filter( fn( $class ) => $this->isValidTeam( $class ) )
+			->values();
+
+		return $models->all();
+	}
+
+	public function isValidTeam( string $model ): bool {
+		if( ! class_exists( $model ) ){
+			return false;
+		}
+
+		$reflection = new ReflectionClass( $model );
+
+		if( $reflection->isAbstract() ){
+			return false;
+		}
+
+		if( ! $reflection->isSubclassOf( Model::class ) ) {
+			return false;
+		}
+
+		if( ! array_key_exists( HasTeam::class, $reflection->getTraits() ) ){
+			return false;
+		}
+
+		return true;
+	}
+
+	public function getTeamCounts( string $class ): array{
+		return $class::withCount([ 'members', 'invitations' ])->orderBy( 'members_count', 'ASC' )->get()->all();
+	}
+}

--- a/src/Providers/TeamsyServiceProvider.php
+++ b/src/Providers/TeamsyServiceProvider.php
@@ -7,6 +7,7 @@ use Illuminate\Support\Facades\Event;
 use Illuminate\Support\Facades\Gate;
 use Illuminate\Support\ServiceProvider;
 use WRD\Teamsy\Capabilities\RolesRegistry;
+use WRD\Teamsy\Console\Commands\AbandonedCommand;
 use WRD\Teamsy\Events\InviteCreated;
 use WRD\Teamsy\Events\LeavingTeam;
 use WRD\Teamsy\Events\MemberDeleting;
@@ -22,7 +23,6 @@ use WRD\Teamsy\Listeners\RevokeNoLongerAllowedInvitations;
 use WRD\Teamsy\Listeners\SendInvitation;
 use WRD\Teamsy\Models\Invitation;
 use WRD\Teamsy\Models\Membership;
-use WRD\Teamsy\Support\Facades\Roles;
 
 final class TeamsyServiceProvider extends ServiceProvider {
 	/**
@@ -83,6 +83,12 @@ final class TeamsyServiceProvider extends ServiceProvider {
 		Event::listen(MemberDeleting::class, CleanUpMember::class);
 		
 		Event::listen(InviteCreated::class, SendInvitation::class);
+
+		if ($this->app->runningInConsole()) {
+			$this->commands([
+				AbandonedCommand::class
+			]);
+		}
 
 		$this->publishes([
 			__DIR__ . '/../../config/teamsy.php' => config_path( 'teamsy.php' ),


### PR DESCRIPTION
Starts progress on #4 - adding tooling to manage abandoned teams

Adds a new command (`teamsy:abandoned`) to list all of the abandoned teams in an app.

Also introduces the TeamInspector which may be useful for #9, so that we can identify teams and relationships to them.

