### PR TITLE
Added HasTeam relation

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -37,18 +37,17 @@ Teamsy will automatically create a relationship from your team model to your use
 
 To aid in determining which of your user model's attributes are for teams, you should use the `#[Team()]` annotation on team relation functions. See the example below.
 
-> Whilst the Team attribute is optional, it allows Teamsy to get a list of all your model's teams using in the `getAllTeamRelationships` method. We use this to automatically remove memberships & sent invitations when a user is deleted.
+> Whilst the Team attribute is optional, it allows Teamsy to get a list of all your model's teams using in the `TeamInspector::getTeamRelationships` method. We use this to automatically remove memberships & sent invitations when a user is deleted.
 
 ```php
-use WRD\Teamsy\Attributes\Team;
 use WRD\Teamsy\Traits\JoinsTeam;
+use WRD\Teamsy\Models\Relations\HasTeam;
 
 class User{
 	use JoinsTeam;
 
-	#[Team()]
-	public function organisations(): MorphToMany{
-		return $this->joinsTeam(Organisation::class);
+	public function hasTeam(): HasTeam{
+		return $this->hasTeam(Organisation::class);
 	}
 }
 ```
@@ -117,9 +116,9 @@ trait JoinsTeam{
 	/**
 	  * Create a relationship between the user an a team.
 	  *
-	  * @return \Illuminate\Database\Eloquent\Relations\MorphToMany<Team, $this>
+	  * @return \Illuminate\Database\Eloquent\Relations\HasTeam<Team, $this>
 	  */
-	public function joinsTeam( string $team_class );
+	public function hasTeam( string $team_class );
 
 	/**
 	  * Query the relationship for a user's pending invitations.
@@ -127,85 +126,76 @@ trait JoinsTeam{
 	  * @return \Illuminate\Database\Eloquent\Builder|\Illuminate\Database\Query\Builder
 	  */
 	public function pendingInvitations();
-	
+
 	/**
 	 * Query the relationship for a user's declined invitations.
 	 *
 	 * @return \Illuminate\Database\Eloquent\Builder|\Illuminate\Database\Query\Builder
 	 */
 	public function getDeclinedInvitations();
-	
+
 	/**
 	 * Get the relationship for a user's sent invitations.
 	 *
 	 * @return \Illuminate\Database\Eloquent\Relations\HasMany<Team, $this>
 	 */
 	public function sentInvitations();
-	
+
 	/**
 	 * Get the user's membership to a team.
 	 *
 	 * @return \WRD\Teamsy\Models\Membership|null
 	 */
 	public function getMembershipIn( Model $team, string $relationship = null );
-	
+
 	/**
 	 * Get the user's role in a team.
 	 *
 	 * @return \WRD\Teamsy\Capabilities\Role
 	 */
 	public function getRoleIn( Model $team, string $relationship = null );
-	
+
 	/**
 	 * Check if the user can perform a capability in a team.
 	 *
 	 * @return bool
 	 */
 	public function canIn( Model $team, string $capability, string $relationship = null );
-	
+
 	/**
 	 * Set the user's role in a team.
 	 *
 	 * @return \WRD\Teamsy\Models\Role
 	 */
 	public function setRoleIn( Model $team, string $role, string $relationship = null );
-	
+
 	/**
 	 * Check if the user is in a team.
 	 *
 	 * @return void
 	 */
 	public function inTeam( Model $team );
-	
+
 	/**
 	 * Add the user to a team.
 	 *
 	 * @return void
 	 */
 	public function joinTeam( Model $team, string $role_id );
-	
+
 	/**
 	 * Invite the user to a team.
 	 *
 	 * @return \WRD\Teamsy\Models\Invitation
 	 */
 	public function inviteToTeam( Model $team, string $role_id, ?Model $invitor = null, ?string $message = null );
-	
+
 	/**
 	 * Remove the user from a team.
 	 *
 	 * @return void
 	 */
 	public function leaveTeam( Model $team, string $relationship = null );
-	
-	/**
-	 * Get all of this model's relationships that are a team relationship.
-	 *
-	 * You should denote team relations with the #[Team()] annotation.
-	 *
-	 * @return string[]
-	 */
-	public function getAllTeamRelationships();
 }
 ```
 
@@ -415,42 +405,42 @@ class Invitation extends Model implements Membershipish{
 	 * @return bool
 	 */
 	public function isDeclined();
-	
+
 	/**
 	 * Revoke an invitation so the invitee cannot accept it.
 	 *
 	 * @return void
 	 */
 	public function revoke();
-	
+
 	/**
 	 * Accept an invitation and join the team.
 	 *
 	 * @return void
 	 */
 	public function accept();
-	
+
 	/**
 	 * Decline an invitation, such that it cannot be sent again.
 	 *
 	 * @return void
 	 */
 	public function decline();
-	
+
 	/**
 	 * Invite a user to join a team.
 	 *
 	 * @return \WRD\Teamsy\Models\Invitation
 	 */
 	static public function createForUser( Model $team, Model $invitee, string $role_id, Model $sender = null, string $message = null );
-	
+
 	/**
 	 * Checks if there is an invitation for an email address in a team.
 	 *
 	 * @return bool
 	 */
 	static public function existsForEmail( Model $team, string $email );
-	
+
 	/**
 	 * Invite a new user by their email address to join a team.
 	 *

--- a/src/Attributes/Team.php
+++ b/src/Attributes/Team.php
@@ -1,8 +1,0 @@
-<?php
-
-namespace WRD\Teamsy\Attributes;
-
-use Attribute;
-
-#[Attribute(Attribute::TARGET_METHOD)]
-class Team{}

--- a/src/Listeners/CleanUpMember.php
+++ b/src/Listeners/CleanUpMember.php
@@ -3,17 +3,19 @@
 namespace WRD\Teamsy\Listeners;
 
 use WRD\Teamsy\Events\MemberDeleting;
+use WRD\Teamsy\Models\TeamInspector;
 
 class CleanUpMember
 {
     public function handle( MemberDeleting $event ) {
+		$inspector = new TeamInspector();
 		$user = $event->member;
 
         // Delete invitations sent by the user.
 		$user->sentInvitations()->forceDelete();
 
 		// Delete all memberships for the user.
-		foreach( $user->getAllTeamRelationships() as $relationship ){
+		foreach( $inspector->getTeamRelationships( $user ) as $relationship ){
 			$user->{$relationship}()->delete();
 		}
     }

--- a/src/Models/Relations/HasTeam.php
+++ b/src/Models/Relations/HasTeam.php
@@ -1,0 +1,7 @@
+<?php
+
+namespace WRD\Teamsy\Models\Relations;
+
+use Illuminate\Database\Eloquent\Relations\MorphToMany;
+
+class HasTeam extends MorphToMany{}

--- a/src/Models/TeamInspector.php
+++ b/src/Models/TeamInspector.php
@@ -2,10 +2,13 @@
 
 namespace WRD\Teamsy\Models;
 
+use Exception;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Support\Facades\File;
 use Illuminate\Support\Str;
 use ReflectionClass;
+use ReflectionMethod;
+use ReflectionNamedType;
 use WRD\Teamsy\Traits\HasTeam;
 
 class TeamInspector{
@@ -49,5 +52,60 @@ class TeamInspector{
 
 	public function getTeamCounts( string $class ): array{
 		return $class::withCount([ 'members', 'invitations' ])->orderBy( 'members_count', 'ASC' )->get()->all();
+	}
+
+	/**
+	 * Get all team relationship names for a model
+	 * 
+	 * @param Model|string The class name of the model or an instance of a model.
+	 * 
+	 * @return string[]
+	 */
+	public function getTeamRelationships( Model|string $model ): array{
+		$reflection = new ReflectionClass( $model );
+
+		if( $reflection->isAbstract() ){
+			throw new Exception( 'getTeamRelationships: Argument 0 cannot be abstract.' );
+		}
+
+		if( ! $reflection->isSubclassOf( Model::class ) ) {
+			throw new Exception( 'getTeamRelationships: Argument 0 must by of a subclass of Model.' );
+		}
+
+		$methods = $reflection->getMethods( ReflectionMethod::IS_PUBLIC );
+		$relations = [];
+
+		foreach( $methods as $method ){
+			if( $this->isTeamRelationshipMethod( $method ) ){
+				$relations[] = $method->getName();
+			}
+		}
+
+		return $relations;
+	}
+
+	/**
+	 * Checks if a reflection method is a valid team relationship.
+	 * 
+	 * @param ReflectionMethod $method
+	 * 
+	 * @return bool
+	 */
+	public function isTeamRelationshipMethod( ReflectionMethod $method ): bool{
+		if( ! $method->isPublic()
+			|| $method->isAbstract()
+			|| $method->getDeclaringClass()->getName() === Model::class
+			|| $method->getNumberOfParameters() > 0
+		){
+			return false;
+		}
+
+		$return = $method->getReturnType();
+
+		if( ! $return instanceof ReflectionNamedType ){
+			return false;
+		}
+
+		return is_subclass_of( $return->getName(), HasTeam::class);
 	}
 }


### PR DESCRIPTION
- Removes the `Team` attribute.
- Adds a new relation type, `HasTeam`, which extends `MorphToMany`.
- Renamed the `joinsTeam` method to `hasTeam`, bringing it inline with the Laravel relationship naming convention.
- Move methods to gather all of a member's teams to the `TeamInspector` class. This now also uses the return type of `HasTeam` rather than the attribute.
- Updated docs to match changes.

Fixes #9 